### PR TITLE
carbon_initialize: Stage-1-only add_carbon_tasks (build SEALS7 lookup); consumers own Stage-2

### DIFF
--- a/global_invest/carbon/carbon_functions.py
+++ b/global_invest/carbon/carbon_functions.py
@@ -19,6 +19,7 @@ import pandas as pd
 import numpy as np
 from tqdm import tqdm
 import geopandas as gpd
+import hazelbean as hb
 
 
 # =============================================================================
@@ -149,45 +150,30 @@ def reproject_raster(
     reference_path,
     output_path,
     compress="lzw",
-    chunks={"x": 1024, "y": 1024},
-    overwrite=False
+    chunks=None,          # kept for signature compatibility; hazelbean handles chunking internally
+    overwrite=False,
+    resample_method="near",
     ):
     """
-    Reproject a raster to match the CRS, resolution, and extent of a reference raster.
+    Resample/reproject a raster to match the CRS, resolution and extent of a reference
+    raster, via hazelbean (rule #127: geospatial ops go through hb, not raw rioxarray/gdal).
 
-    Parameters
-    ----------
-    input_path : str
-        Path to the raster to reproject.
-    reference_path : str
-        Path to the reference raster.
-    output_path : str
-        Path to save the reprojected raster.
-    compress : str
-        Compression method for output (default: 'lzw').
-    chunks : dict
-        Chunk size for Dask loading (default: {"x": 1024, "y": 1024}).
-    overwrite : bool
-        Whether to overwrite an existing file.
+    resample_method defaults to "near" to preserve the values-as-built behaviour of the prior
+    `rioxarray.reproject_match` (which defaulted to nearest). ⚠ If switching to "bilinear" for
+    continuous density, do it alongside a lookup-rebuild + diff against the current base_data
+    lookup — the choice changes the per-(class,zone) means.
     """
     if os.path.exists(output_path) and not overwrite:
         raise FileExistsError(f"{output_path} exists. Use overwrite=True to replace it.")
 
-    ref = rxr.open_rasterio(reference_path, masked=True, chunks=chunks).squeeze("band", drop=True)
-    target = rxr.open_rasterio(input_path, masked=True, chunks=chunks).squeeze("band", drop=True)
-
-    reprojected = target.rio.reproject_match(ref)
-
-    reprojected.rio.to_raster(
+    hb.resample_to_match(
+        input_path,
+        reference_path,
         output_path,
-        compress=compress,
-        tiled=True,
-        blockxsize=256,
-        blockysize=256
+        resample_method=resample_method,
+        compress=bool(compress),
     )
-
     print(f"Reprojected raster saved to: {output_path}")
-    del ref, target, reprojected
     gc.collect()
 
 

--- a/global_invest/carbon/carbon_initialize.py
+++ b/global_invest/carbon/carbon_initialize.py
@@ -1,13 +1,17 @@
 """Task-tree builders for the global_invest carbon (storage & sequestration) model.
 
-Import this to attach the carbon tasks to any ProjectFlow tree:
+`add_carbon_tasks(p, parent)` registers STAGE-1: it builds the SEALS7 carbon-density lookup
+(LULC class x carbon zone -> tC/ha). It is the reproducible BUILDER of the lookup, used by
+run_carbon.py (standalone) and for regeneration:
 
     from global_invest.carbon import carbon_initialize
-    carbon_initialize.add_carbon_tasks(p)                     # stand-alone (run_carbon.py)
-    carbon_initialize.add_carbon_tasks(p, parent=p.es_task)   # embedded (run_nff_global.py / run_ngfs_pnas.py)
+    carbon_initialize.initialize_paths(p)
+    carbon_initialize.add_carbon_tasks(p)                     # or parent=p.es_task to nest it
 
-This lifts the task tree out of run_carbon.py so the carbon model is reusable as a
-sub-tree in other projects, following the per-service structure
+Consumers do NOT need this hook: nff_global / ngfs_pnas read the prebuilt lookup at
+p.carbon_density_lookup_table_path and call carbon_functions.generate_carbon_density_raster to
+apply it per scenario map, then do their own downstream step (nff keeps the density raster;
+ngfs does r50 -> frs shock). Follows the per-service structure
 (run_<svc> / <svc>_tasks / <svc>_functions / <svc>_initialize).
 """
 from global_invest.carbon import carbon_tasks
@@ -16,19 +20,29 @@ from global_invest.carbon import carbon_tasks
 def initialize_paths(p):
     """Set the carbon input paths on p, resolved against p.base_data_dir via
     p.get_path (path components relative to base_data; downloads on demand). The
-    caller sets p.base_data_dir (and p.aoi) before calling."""
-    p.base_year_lulc_path = p.get_path('lulc', 'esa', 'lulc_esa_2019.tif')
-    p.all_lulcs_path = p.get_path('lulc', 'esa')
+    caller sets p.base_data_dir before calling."""
+    # SEALS7 base map (NOT ESA): the lookup must be keyed on SEALS7 classes so it matches
+    # the downscaled maps consumers apply it to. Building from lulc_esa_2019 would key the
+    # table on ESA classes, which the SEALS7 consumer maps cannot index.
+    p.base_year_lulc_path = p.get_path('carbon_storage', 'lulc_seals7_2020_from_esa.tif')
     p.carbon_zones_path = p.get_path('carbon_storage', 'carbon_zones_rasterized.tif')
+    # Canonical lookup: Stage-1 builds it; every consumer (nff/ngfs) reads it from here.
+    p.carbon_density_lookup_table_path = p.get_path('carbon_storage', 'carbon_density_lookup_seals7_spawn.csv')
     p.region_boundary_path = p.get_path('cartographic', 'ee', 'ee_r264_correspondence.gpkg')
     return p
 
 
 def add_carbon_tasks(p, parent=None):
-    """Attach the carbon task chain to p's task tree (under `parent` if given), return p.
+    """Attach the carbon STAGE-1 chain to p's task tree (under `parent` if given), return p.
 
-    Stage 1 (build once): convert -> combine (AGB + BGB) -> reproject -> density table.
-    Stage 2 (apply per map): generate the carbon-density raster, then summarize by region.
+    Stage 1 (build the lookup, once): convert Spawn dtype -> combine AGB+BGB -> reproject to
+    the LULC grid -> compute the (SEALS7 class x carbon zone) -> tC/ha lookup table.
+
+    Stage 2 (apply the lookup to a map) is deliberately NOT here — each consumer owns it, so
+    global_invest.carbon stays free of consumer-specific logic (e.g. GTAP r50/shock). Consumers
+    read p.carbon_density_lookup_table_path and call the public
+    carbon_functions.generate_carbon_density_raster(lulc, zones, lookup, out); run_carbon.py adds
+    the base-year Stage-2 for standalone use.
     """
     p.task_convert_carbon_density_maps_dtype = p.add_task(
         carbon_tasks.task_convert_carbon_density_maps_dtype, parent=parent)
@@ -37,9 +51,5 @@ def add_carbon_tasks(p, parent=None):
     p.task_reproject_total_carbon_density = p.add_task(
         carbon_tasks.task_reproject_total_carbon_density, parent=parent)
     p.task_compute_carbon_density_table = p.add_task(
-        carbon_tasks.task_compute_carbon_density_table, parent=parent)               # Stage 1: LULC x zone -> tC/ha lookup
-    p.task_generate_carbon_density_raster_base_year = p.add_task(
-        carbon_tasks.task_generate_carbon_density_raster_base_year, parent=parent)   # Stage 2: apply lookup to a map
-    p.task_summarize_carbon_density_by_region = p.add_task(
-        carbon_tasks.task_summarize_carbon_density_by_region, parent=parent)
+        carbon_tasks.task_compute_carbon_density_table, parent=parent)               # -> the SEALS7 lookup CSV
     return p

--- a/global_invest/carbon/carbon_initialize.py
+++ b/global_invest/carbon/carbon_initialize.py
@@ -1,0 +1,45 @@
+"""Task-tree builders for the global_invest carbon (storage & sequestration) model.
+
+Import this to attach the carbon tasks to any ProjectFlow tree:
+
+    from global_invest.carbon import carbon_initialize
+    carbon_initialize.add_carbon_tasks(p)                     # stand-alone (run_carbon.py)
+    carbon_initialize.add_carbon_tasks(p, parent=p.es_task)   # embedded (run_nff_global.py / run_ngfs_pnas.py)
+
+This lifts the task tree out of run_carbon.py so the carbon model is reusable as a
+sub-tree in other projects, following the per-service structure
+(run_<svc> / <svc>_tasks / <svc>_functions / <svc>_initialize).
+"""
+from global_invest.carbon import carbon_tasks
+
+
+def initialize_paths(p):
+    """Set the carbon input paths on p, resolved against p.base_data_dir via
+    p.get_path (path components relative to base_data; downloads on demand). The
+    caller sets p.base_data_dir (and p.aoi) before calling."""
+    p.base_year_lulc_path = p.get_path('lulc', 'esa', 'lulc_esa_2019.tif')
+    p.all_lulcs_path = p.get_path('lulc', 'esa')
+    p.carbon_zones_path = p.get_path('carbon_storage', 'carbon_zones_rasterized.tif')
+    p.region_boundary_path = p.get_path('cartographic', 'ee', 'ee_r264_correspondence.gpkg')
+    return p
+
+
+def add_carbon_tasks(p, parent=None):
+    """Attach the carbon task chain to p's task tree (under `parent` if given), return p.
+
+    Stage 1 (build once): convert -> combine (AGB + BGB) -> reproject -> density table.
+    Stage 2 (apply per map): generate the carbon-density raster, then summarize by region.
+    """
+    p.task_convert_carbon_density_maps_dtype = p.add_task(
+        carbon_tasks.task_convert_carbon_density_maps_dtype, parent=parent)
+    p.task_combine_two_carbon_density_maps = p.add_task(
+        carbon_tasks.task_combine_two_carbon_density_maps, parent=parent)
+    p.task_reproject_total_carbon_density = p.add_task(
+        carbon_tasks.task_reproject_total_carbon_density, parent=parent)
+    p.task_compute_carbon_density_table = p.add_task(
+        carbon_tasks.task_compute_carbon_density_table, parent=parent)               # Stage 1: LULC x zone -> tC/ha lookup
+    p.task_generate_carbon_density_raster_base_year = p.add_task(
+        carbon_tasks.task_generate_carbon_density_raster_base_year, parent=parent)   # Stage 2: apply lookup to a map
+    p.task_summarize_carbon_density_by_region = p.add_task(
+        carbon_tasks.task_summarize_carbon_density_by_region, parent=parent)
+    return p

--- a/global_invest/carbon/run_carbon.py
+++ b/global_invest/carbon/run_carbon.py
@@ -1,56 +1,44 @@
 # Copyright (c) 2025, Yanxu Long
 # This file is part of the Global GEP project: carbon storage and sequestration
+#
+# Stand-alone runner for the carbon model. Builds the SEALS7 carbon-density lookup
+# (Stage 1, via carbon_initialize.add_carbon_tasks) then applies it to the base-year map
+# and summarizes by region (Stage 2, standalone only). Consumers (nff/ngfs) do NOT run this
+# file: they read the lookup and call carbon_functions.generate_carbon_density_raster.
 
-import os, sys
+import os
 import hazelbean as hb
-import pandas as pd
 
-from global_invest.carbon import carbon_tasks
+from global_invest.carbon import carbon_tasks, carbon_initialize
 
-# Create the project flow object
-p = hb.ProjectFlow()
-
-# Set project-directories
-p.user_dir = os.path.expanduser('~')
-p.extra_dirs = ['Files', 'global_invest', 'projects']
-p.project_name = p.project_name + '_' + hb.pretty_time() # Comment this line out if you want it to use an existing project. Will skip recreation of files that already exist.
-p.project_dir = os.path.join(p.user_dir, os.sep.join(p.extra_dirs), p.project_name)
-p.set_project_dir(p.project_dir)
-
-# Set basa_data_dir. Will download required files here.
-p.base_data_dir = "/Users/long/Library/CloudStorage/GoogleDrive-yxlong@umn.edu/Shared drives/NatCapTEEMs/Files/base_data/submissions/carbon/spawn_2020"
-# p.base_data_dir = os.path.join(p.user_dir, 'Files', 'base_data') # Uncomment this line if you want to use the default base_data_dir
-
-# Set model-paths
-p.aoi = 'global' #p.aoi = 'RWA'
-p.base_year_lulc_path = p.get_path(os.path.join(p.base_data_dir,'lulc/esa/lulc_esa_2019.tif')) # Defines the fine_resolution
-p.all_lulcs_path = p.get_path(os.path.join(p.base_data_dir, 'lulc/esa')) # Defines the all_lulcs
-p.carbon_zones_path = p.get_path(os.path.join(p.base_data_dir,'carbon_zones_rasterized.tif')) # Defines the carbon zones
-p.region_boundary_path = p.get_path(os.path.join(p.base_data_dir,'ee_r264_correspondence.gpkg'))
 
 def build_task_tree(p):
-    p.task_print_hello = p.add_task(carbon_tasks.task_print_hello)
-    p.task_convert_carbon_density_maps_dtype = p.add_task(carbon_tasks.task_convert_carbon_density_maps_dtype)
-    p.task_combine_two_carbon_density_maps = p.add_task(carbon_tasks.task_combine_two_carbon_density_maps)
-    p.task_reproject_total_carbon_density = p.add_task(carbon_tasks.task_reproject_total_carbon_density)
-    p.task_compute_carbon_density_table = p.add_task(carbon_tasks.task_compute_carbon_density_table)
+    # Stage 1: build the SEALS7 carbon-density lookup (the reusable seam).
+    carbon_initialize.add_carbon_tasks(p)
+    # Stage 2 (standalone only): apply the lookup to the base-year map, then summarize by region.
     p.task_generate_carbon_density_raster_base_year = p.add_task(carbon_tasks.task_generate_carbon_density_raster_base_year)
     p.task_summarize_carbon_density_by_region = p.add_task(carbon_tasks.task_summarize_carbon_density_by_region)
 
-# Build the task tree and excute it!
-build_task_tree(p)
-p.fail_fast = True
-p.verbosity = 2
-p.debug = True
-p.execute()
 
+if __name__ == '__main__':
+    p = hb.ProjectFlow()
 
+    # Project directories.
+    p.user_dir = os.path.expanduser('~')
+    p.extra_dirs = ['Files', 'global_invest', 'projects']
+    p.project_name = p.project_name + '_' + hb.pretty_time()  # comment out to reuse an existing project
+    p.project_dir = os.path.join(p.user_dir, os.sep.join(p.extra_dirs), p.project_name)
+    p.set_project_dir(p.project_dir)
 
+    # Base data. Portable default; carbon inputs live under base_data/carbon_storage.
+    p.base_data_dir = os.path.join(p.user_dir, 'Files', 'base_data')
+    p.aoi = 'global'
 
+    # Resolve carbon input paths (SEALS7 base map, carbon zones, lookup, regions).
+    carbon_initialize.initialize_paths(p)
 
-
-
-
-
-
-
+    build_task_tree(p)
+    p.fail_fast = True
+    p.verbosity = 2
+    p.debug = True
+    p.execute()


### PR DESCRIPTION
Adds `carbon_initialize.py` and gives the carbon module its wiring seam.

**`add_carbon_tasks(p, parent=None)` = Stage-1 only** — builds the SEALS7 carbon-density lookup (convert Spawn dtype → combine AGB+BGB → reproject to LULC grid → compute the `(class × zone) → tC/ha` table). Stage-2 (apply the lookup to a map) is deliberately NOT in the hook, so `global_invest.carbon` stays free of consumer-specific logic (e.g. GTAP r50 aggregation / shocks) — a layering boundary.

**Consumer contract:** downstream projects READ the prebuilt lookup at `p.carbon_density_lookup_table_path` and call the public `carbon_functions.generate_carbon_density_raster(lulc, zones, lookup, out)` per scenario map, then do their own downstream step. They do not build the lookup.

**`initialize_paths(p)`:** base map is the SEALS7 map (`lulc_seals7_2020_from_esa.tif`), so the lookup is keyed on SEALS7 classes matching the maps it's applied to (an ESA base map would key it on ESA classes the SEALS7 maps can't index); exposes the canonical `p.carbon_density_lookup_table_path`; drops the dead `all_lulcs_path`.

**`reproject_raster`** now uses `hb.resample_to_match` instead of raw `rioxarray.reproject_match` (`resample_method='near'` preserves prior nearest behaviour).

**`run_carbon.py`** now consumes `carbon_initialize` (Stage-1 hook + base-year Stage-2), drops an undefined task reference, uses a portable base_data dir, and adds a `__main__` guard so it imports cleanly.

**Follow-up (separate PR):** finish the hazelbean conform of the remaining raster ops in `carbon_functions.py` (`combine`, zonal, scale) — these change nodata/resampling semantics, so they land only after a lookup-rebuild-and-diff against the current base_data lookup.

**Scope note:** this PR is the interface + importable standalone. The lookup consumers use already exists in `base_data/carbon_storage/`. Rebuilding it from scratch via `run_carbon.py` additionally needs the raw Spawn AGB/BGB inputs staged (base_data currently holds only the combined total), which lands with the validated hazelbean-conform rebuild above.
